### PR TITLE
[docs] fixed examples to use tubes instead of twisted.tubes, other minor changes

### DIFF
--- a/docs/listings/echoflow.py
+++ b/docs/listings/echoflow.py
@@ -11,6 +11,7 @@ def main(reactor, listenOn="stdio:"):
     endpoint.listen(factoryFromFlow(echoFlow))
     return Deferred()
 
-from twisted.internet.task import react
-from sys import argv
-react(main, argv[1:])
+if __name__ == '__main__':
+    from twisted.internet.task import react
+    from sys import argv
+    react(main, argv[1:])

--- a/docs/listings/echonetstrings.py
+++ b/docs/listings/echonetstrings.py
@@ -1,6 +1,6 @@
-from twisted.tubes.tube import Tube
-from twisted.tubes.framing import stringsToNetstrings
-from twisted.tubes.protocol import factoryFromFlow
+from tubes.tube import Tube
+from tubes.framing import stringsToNetstrings
+from tubes.protocol import factoryFromFlow
 from twisted.internet.endpoints import TCP4ServerEndpoint
 from twisted.internet.defer import Deferred
 
@@ -13,5 +13,6 @@ def main(reactor):
     endpoint.listen(factoryFromFlow(echoTubeFactory))
     return Deferred()
 
-from twisted.internet.task import react
-react(main, [])
+if __name__ == '__main__':
+    from twisted.internet.task import react
+    react(main, [])

--- a/docs/listings/portforward.py
+++ b/docs/listings/portforward.py
@@ -1,7 +1,6 @@
-
 import os
 
-from twisted.tubes.protocol import factoryFromFlow
+from tubes.protocol import factoryFromFlow
 from twisted.internet.endpoints import serverFromString, clientFromString
 from twisted.internet.defer import Deferred
 
@@ -18,6 +17,7 @@ def main(reactor, listen="tcp:4321", connect="tcp:localhost:6543"):
     serverEndpoint.listen(factoryFromFlow(incomingTubeFactory))
     return Deferred()
 
-from twisted.internet.task import react
-from sys import argv
-react(main, argv[1:])
+if __name__ == '__main__':
+    from twisted.internet.task import react
+    from sys import argv
+    react(main, argv[1:])

--- a/docs/listings/reversetube.py
+++ b/docs/listings/reversetube.py
@@ -1,7 +1,7 @@
-from twisted.tubes.protocol import factoryFromFlow
+from tubes.protocol import factoryFromFlow
 from twisted.internet.endpoints import serverFromString
 from twisted.internet.defer import Deferred
-from twisted.tubes.tube import tube, series
+from tubes.tube import tube, series
 
 @tube
 class Reverser(object):
@@ -9,7 +9,7 @@ class Reverser(object):
         yield b"".join(reversed(item))
 
 def reverseFlow(fount, drain):
-    from twisted.tubes.framing import bytesToLines, linesToBytes
+    from tubes.framing import bytesToLines, linesToBytes
     lineReverser = series(bytesToLines(), Reverser(), linesToBytes())
     fount.flowTo(lineReverser).flowTo(drain)
 
@@ -18,7 +18,7 @@ def main(reactor, listenOn="stdio:"):
     endpoint.listen(factoryFromFlow(reverseFlow))
     return Deferred()
 
-from twisted.internet.task import react
-
-from sys import argv
-react(main, argv[1:])
+if __name__ == '__main__':
+    from twisted.internet.task import react
+    from sys import argv
+    react(main, argv[1:])

--- a/docs/listings/rpn.py
+++ b/docs/listings/rpn.py
@@ -1,4 +1,3 @@
-
 from tubes.protocol import factoryFromFlow
 from tubes.itube import IFrame, ISegment
 from tubes.tube import tube, receiver
@@ -56,9 +55,9 @@ class Prompter(object):
         yield "> "
 
 def promptingCalculatorSeries():
-    from twisted.tubes.fan import Thru
-    from twisted.tubes.tube import series
-    from twisted.tubes.framing import bytesToLines, linesToBytes
+    from tubes.fan import Thru
+    from tubes.tube import series
+    from tubes.framing import bytesToLines, linesToBytes
 
     full = series(bytesToLines(),
                   Thru([series(linesToNumbersOrOperators,
@@ -69,8 +68,8 @@ def promptingCalculatorSeries():
     return full
 
 def calculatorSeries():
-    from twisted.tubes.tube import series
-    from twisted.tubes.framing import bytesToLines, linesToBytes
+    from tubes.tube import series
+    from tubes.framing import bytesToLines, linesToBytes
 
     return series(
         bytesToLines(),
@@ -90,6 +89,7 @@ def main(reactor, port="stdio:"):
     endpoint.listen(factoryFromFlow(mathFlow))
     return Deferred()
 
-from twisted.internet.task import react
-from sys import argv
-react(main, argv[1:])
+if __name__ == '__main__':
+    from twisted.internet.task import react
+    from sys import argv
+    react(main, argv[1:])


### PR DESCRIPTION
Minor but helpful if you're starting out.