### PR TITLE
fix location for 'tubes.*' docs

### DIFF
--- a/docs/_extensions/apilinks.py
+++ b/docs/_extensions/apilinks.py
@@ -27,7 +27,10 @@ def make_api_link(name, rawtext, text, lineno, inliner,
 
     #get the base url for api links from the config file
     env = inliner.document.settings.env
-    base_url =  env.config.apilinks_base_url
+    if full_name.startswith("twisted"):
+        base_url = env.config.apilinks_base_url
+    else:
+        base_url = "https://twisted.github.io/tubes/docs/"
 
     # not really sufficient, but just testing...
     # ...hmmm, maybe this is good enough after all


### PR DESCRIPTION
address the base URL issue raised in #31

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/twisted/tubes/34)
<!-- Reviewable:end -->
