### PR TITLE
Half close

### DIFF
--- a/tubes/protocol.py
+++ b/tubes/protocol.py
@@ -294,6 +294,7 @@ class _ProtocolPlumbing(_Protocol):
         self._drain.fount = None
 
 
+
 def _factoryFromFlow(flow):
     """
     Convert a flow function into an L{IProtocolFactory}.

--- a/tubes/protocol.py
+++ b/tubes/protocol.py
@@ -24,6 +24,7 @@ from twisted.internet.interfaces import (
     IPushProducer, IListeningPort, IHalfCloseableProtocol
 )
 from twisted.internet.protocol import Protocol as _Protocol
+from twisted.internet.error import ConnectionDone
 
 if 0:
     # Workaround for inability of pydoctor to resolve references.
@@ -281,12 +282,16 @@ class _ProtocolPlumbing(_Protocol):
         """
         An end-of-file was received.
         """
+        self._fount.drain.flowStopped(Failure(ConnectionDone()))
+        self._fount.drain = None
 
 
     def writeConnectionLost(self):
         """
         The write output was closed.
         """
+        self._drain.fount.stopFlow()
+        self._drain.fount = None
 
 
 def _factoryFromFlow(flow):

--- a/tubes/protocol.py
+++ b/tubes/protocol.py
@@ -20,7 +20,9 @@ from .itube import StopFlowCalled, IDrain, IFount, ISegment
 from .listening import Flow
 
 from twisted.python.failure import Failure
-from twisted.internet.interfaces import IPushProducer, IListeningPort
+from twisted.internet.interfaces import (
+    IPushProducer, IListeningPort, IHalfCloseableProtocol
+)
 from twisted.internet.protocol import Protocol as _Protocol
 
 if 0:
@@ -206,6 +208,7 @@ class _TransportFount(object):
 
 
 
+@implementer(IHalfCloseableProtocol)
 class _ProtocolPlumbing(_Protocol):
     """
     An adapter between an L{ITransport} and L{IFount} / L{IDrain} interfaces.
@@ -273,6 +276,17 @@ class _ProtocolPlumbing(_Protocol):
         if self._drain.fount is not None:
             self._drain.fount.stopFlow()
 
+
+    def readConnectionLost(self):
+        """
+        An end-of-file was received.
+        """
+
+
+    def writeConnectionLost(self):
+        """
+        The write output was closed.
+        """
 
 
 def _factoryFromFlow(flow):

--- a/tubes/test/test_protocol.py
+++ b/tubes/test/test_protocol.py
@@ -16,6 +16,7 @@ from twisted.test.proto_helpers import StringTransport
 from twisted.internet.interfaces import (
     IStreamServerEndpoint, IHalfCloseableProtocol
 )
+from twisted.internet.error import ConnectionDone
 
 from ..protocol import flowFountFromEndpoint, flowFromEndpoint
 from ..tube import tube, series
@@ -407,7 +408,7 @@ class FlowListenerTests(TestCase):
         self.assertEqual(ports[0].currentlyProducing, True)
 
 
-    def test_halfClose(self):
+    def test_readConnectionLost(self):
         """
         The protocol created by L{flowFountFromEndpoint} provides half-close
         support, and when it receives an EOF (i.e.: C{readConnectionLost}) it
@@ -433,7 +434,45 @@ class FlowListenerTests(TestCase):
         self.assertEqual(dataSender.flowIsStopped, False)
         protocol.readConnectionLost()
         self.assertEqual(len(receivedData.stopped), 1)
+        self.assertIsInstance(receivedData.stopped[0], Failure)
+        receivedData.stopped[0].trap(ConnectionDone)
         self.assertEqual(dataSender.flowIsStopped, False)
+        protocol.connectionLost(ConnectionDone())
+        self.assertEqual(len(receivedData.stopped), 1)
+        self.assertEqual(dataSender.flowIsStopped, True)
+
+
+    def test_writeConnectionLost(self):
+        """
+        The protocol created by L{flowFountFromEndpoint} provides half-close
+        support, and when it receives an EOF (i.e.: C{writeConnectionLost}) it
+        will signal the end of the flow to its drain's fount, but not to its
+        fount's drain.
+        """
+        endpoint, ports = fakeEndpointWithPorts()
+        fffep = flowFountFromEndpoint(endpoint)
+        fffep.callback(None)
+        flowFount = self.successResultOf(fffep)
+        protocol = ports[0].factory.buildProtocol(None)
+        verifyObject(IHalfCloseableProtocol, protocol)
+        aTransport = StringTransport()
+        protocol.makeConnection(aTransport)
+        accepted = FakeDrain()
+        flowFount.flowTo(accepted)
+        [flow] = accepted.received
+        receivedData = FakeDrain()
+        dataSender = FakeFount()
+        flow.fount.flowTo(receivedData)
+        dataSender.flowTo(flow.drain)
+        self.assertEqual(len(receivedData.stopped), 0)
+        self.assertEqual(dataSender.flowIsStopped, False)
+        protocol.writeConnectionLost()
+        self.assertEqual(len(receivedData.stopped), 0)
+        self.assertEqual(dataSender.flowIsStopped, 1)
+        protocol.connectionLost(ConnectionDone())
+        self.assertEqual(len(receivedData.stopped), 1)
+        self.assertEqual(dataSender.flowIsStopped, 1)
+
 
 
     def test_backpressure(self):

--- a/tubes/test/test_protocol.py
+++ b/tubes/test/test_protocol.py
@@ -474,7 +474,6 @@ class FlowListenerTests(TestCase):
         self.assertEqual(dataSender.flowIsStopped, 1)
 
 
-
     def test_backpressure(self):
         """
         When the L{IFount} returned by L{flowFountFromEndpoint} is paused, it

--- a/tubes/test/test_protocol.py
+++ b/tubes/test/test_protocol.py
@@ -7,12 +7,15 @@ Tests for L{tubes.protocol}.
 """
 
 from zope.interface import implementer
+from zope.interface.verify import verifyObject
 
 from twisted.trial.unittest import SynchronousTestCase as TestCase
 
 from twisted.python.failure import Failure
 from twisted.test.proto_helpers import StringTransport
-from twisted.internet.interfaces import IStreamServerEndpoint
+from twisted.internet.interfaces import (
+    IStreamServerEndpoint, IHalfCloseableProtocol
+)
 
 from ..protocol import flowFountFromEndpoint, flowFromEndpoint
 from ..tube import tube, series
@@ -402,6 +405,35 @@ class FlowListenerTests(TestCase):
         fd = FakeDrain()
         flowFount.flowTo(fd)
         self.assertEqual(ports[0].currentlyProducing, True)
+
+
+    def test_halfClose(self):
+        """
+        The protocol created by L{flowFountFromEndpoint} provides half-close
+        support, and when it receives an EOF (i.e.: C{readConnectionLost}) it
+        will signal the end of the flow to its fount's drain, but not to its
+        drain's fount.
+        """
+        endpoint, ports = fakeEndpointWithPorts()
+        fffep = flowFountFromEndpoint(endpoint)
+        fffep.callback(None)
+        flowFount = self.successResultOf(fffep)
+        protocol = ports[0].factory.buildProtocol(None)
+        verifyObject(IHalfCloseableProtocol, protocol)
+        aTransport = StringTransport()
+        protocol.makeConnection(aTransport)
+        accepted = FakeDrain()
+        flowFount.flowTo(accepted)
+        [flow] = accepted.received
+        receivedData = FakeDrain()
+        dataSender = FakeFount()
+        flow.fount.flowTo(receivedData)
+        dataSender.flowTo(flow.drain)
+        self.assertEqual(len(receivedData.stopped), 0)
+        self.assertEqual(dataSender.flowIsStopped, False)
+        protocol.readConnectionLost()
+        self.assertEqual(len(receivedData.stopped), 1)
+        self.assertEqual(dataSender.flowIsStopped, False)
 
 
     def test_backpressure(self):

--- a/tubes/test/util.py
+++ b/tubes/test/util.py
@@ -171,7 +171,7 @@ class FakeFount(object):
 
     def stopFlow(self):
         """
-        Record that the flow was stopped by setting C{flowIsStopped}.
+        Record that the flow was stopped by incrementing C{flowIsStopped}.
         """
         self.flowIsStopped += 1
 

--- a/tubes/test/util.py
+++ b/tubes/test/util.py
@@ -137,6 +137,7 @@ class FakeFount(object):
 
     flowIsPaused = 0
     flowIsStopped = False
+
     def __init__(self, outputType=None):
         self._pauser = Pauser(self._actuallyPause, self._actuallyResume)
         self.outputType = outputType
@@ -172,7 +173,7 @@ class FakeFount(object):
         """
         Record that the flow was stopped by setting C{flowIsStopped}.
         """
-        self.flowIsStopped = True
+        self.flowIsStopped += 1
 
 
     def _actuallyPause(self):


### PR DESCRIPTION
Fixes #76 

This is pretty basic support - these fount & drain implementations, especially at the edge, want to be state machines.